### PR TITLE
pack compute budget: add effects fields

### DIFF
--- a/proto/pack.proto
+++ b/proto/pack.proto
@@ -12,6 +12,9 @@ message PackComputeBudgetEffects {
     uint64 rewards = 2;
     uint32 heap_sz = 3;
     uint32 loaded_acct_data_sz = 4;
+
+   // To prevent empty effects when encoding a "skipped" effects
+   uint32 is_empty = 5;
 }
 
 message PackComputeBudgetFixture {


### PR DESCRIPTION
- **pack cbp: add heap size and loaded data sz**
- **add is_empty field to prevent solfuzz skip on empty effects**
